### PR TITLE
If key flag is not present, default is false

### DIFF
--- a/ocs_samples/library_samples/Python3/ocs_sample_library_preview/Dataview/DataviewMappingColumn.py
+++ b/ocs_samples/library_samples/Python3/ocs_sample_library_preview/Dataview/DataviewMappingColumn.py
@@ -103,6 +103,8 @@ class DataviewMappingColumn(object):
 
         if 'IsKey' in content:
             dataviewMappingColumn.IsKey = content['IsKey']
+        else:
+            dataviewMappingColumn.IsKey = False
 
         if 'DataType' in content:
             dataviewMappingColumn.DataType = content['DataType']


### PR DESCRIPTION
We should not force a dataview created from a JSON to define IsKey except for the index. 

Without this change, a valid dataview definition (i.e. its JSON can be posted directly) can be converted successfully to a Dataview object with Dataview.fromJson(), but then this object fails with postDataview/putDataview because of an AttributeError exception. 