### PR TITLE
Cbardini patch 1

### DIFF
--- a/samples.json
+++ b/samples.json
@@ -1,0 +1,27 @@
+[
+  {
+    "Title": "Python",
+    "Description": "Sample Sds client written in Python language",
+    "Url": "https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/Python"
+  },
+  {
+    "Title": ".NET",
+    "Description": "Sample Sds client written in C#",
+    "Url": "https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/DotNet"
+  },
+  {
+    "Title": "Java",
+    "Description": "Sample Sds client written in Java",
+    "Url": "https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/Java"
+  },
+  {
+    "Title": "NodeJs",
+    "Description": "Sample Sds client written in NodeJs",
+    "Url": "https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/NodeJS"
+  },
+  {
+    "Title": "Angular",
+    "Description": "Sample Sds client written in Angular",
+    "Url": "https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/Angular"
+  }
+]

--- a/samples.json
+++ b/samples.json
@@ -7,7 +7,7 @@
   {
     "Title": ".NET",
     "Description": "Sample Sds client written in C#",
-    "Url": "https://github.com/osisoft/sample-ocs-waveform-dotnet_libraries"
+    "Url": "https://github.com/osisoft/OSI-Samples-OCS/tree/master/docs/SDS_WAVEFORM_DOTNET_README.md"
   },
   {
     "Title": "Java",

--- a/samples.json
+++ b/samples.json
@@ -2,26 +2,26 @@
   {
     "Title": "Python",
     "Description": "Sample Sds client written in Python language",
-    "Url": "https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/Python"
+    "Url": "https://github.com/osisoft/sample-ocs-waveform-python"
   },
   {
     "Title": ".NET",
     "Description": "Sample Sds client written in C#",
-    "Url": "https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/DotNet"
+    "Url": "https://github.com/osisoft/sample-ocs-waveform-dotnet_libraries"
   },
   {
     "Title": "Java",
     "Description": "Sample Sds client written in Java",
-    "Url": "https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/Java"
+    "Url": "https://github.com/osisoft/sample-ocs-waveform-java"
   },
   {
     "Title": "NodeJs",
     "Description": "Sample Sds client written in NodeJs",
-    "Url": "https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/NodeJS"
+    "Url": "https://github.com/osisoft/sample-ocs-waveform-nodejs"
   },
   {
     "Title": "Angular",
     "Description": "Sample Sds client written in Angular",
-    "Url": "https://github.com/osisoft/OSI-Samples-OCS/tree/master/basic_samples/SDS/Angular"
+    "Url": "https://github.com/osisoft/sample-ocs-waveform-angular"
   }
 ]


### PR DESCRIPTION
The samples.json file was deleted during the reorganization. This pull request recreates it with updated links. The .NET portion originally linked to a folder containing the library and the rest api samples, but this folder no longer exists so I have it temporarily pointing to just the library sample. We can either add an additional section for the rest API or create a readme that points to each sample in the future.