### PR TITLE
Analysis

### DIFF
--- a/miscellaneous/build_templates/analysis.yml
+++ b/miscellaneous/build_templates/analysis.yml
@@ -1,6 +1,6 @@
 parameters:
   skipPolaris: false # For samples that have no code Polaris is capable of scanning
-  useRequirementsTxt: false # Tell the pipeline to use Python requirements.txt for BlackDuck
+  requirementsPath: '' # Specify path to Python requirements.txt for BlackDuck
 
 steps:
   # Synopsys Polaris
@@ -12,7 +12,7 @@ steps:
       # Call Polaris, set the configuration file path and run analyze with wait option
       & 'polaris.exe' -c polaris.yml analyze -w
     workingDirectory: $(Build.SourcesDirectory)$(projPath)/
-    condition: eq(${{ parameters.skipPolaris }}, false)
+    condition: and(succeeded(), eq(${{ parameters.skipPolaris }}, false))
     displayName: 'Polaris Analyze'
 
   # Synopsys BlackDuck
@@ -26,19 +26,6 @@ steps:
         --detect.source.path=$(Build.SourcesDirectory)$(projPath)/
         --detect.code.location.name="code_location_$(analysisProject)_$(Build.SourceBranchName)"
         --detect.bom.aggregate.name="bom_$(analysisProject)_$(Build.SourceBranchName)"
-    condition: and(succeeded(), eq(${{ parameters.useRequirementsTxt }}, false))
+        --detect.pip.requirements.path=${{ parameters.requirementsPath }}
+    condition: succeeded()
     displayName: 'Synopsys Detect: BlackDuck'
-
-  - task: synopsys-detect.synopsys-detect.synopsys-detect-task.SynopsysDetectTask@2
-    inputs:
-      Products: BD
-      BlackDuckService: 'product-readiness.BlackDuck'
-      DetectArguments: |
-        --detect.project.name="product-readiness.$(analysisProject)"
-        --detect.project.version.name="$(Build.SourceBranchName)"
-        --detect.source.path=$(Build.SourcesDirectory)$(projPath)/
-        --detect.code.location.name="code_location_$(analysisProject)_$(Build.SourceBranchName)"
-        --detect.bom.aggregate.name="bom_$(analysisProject)_$(Build.SourceBranchName)"
-        --detect.pip.requirements.path=$(Build.SourcesDirectory)$(projPath)/requirements.txt
-    condition: and(succeeded(), eq(${{ parameters.useRequirementsTxt }}, true))
-    displayName: 'Synopsys Detect: BlackDuck (Python Requirements.txt)'

--- a/miscellaneous/build_templates/analysis.yml
+++ b/miscellaneous/build_templates/analysis.yml
@@ -1,6 +1,6 @@
 parameters:
   skipPolaris: false # For samples that have no code Polaris is capable of scanning
-  useRequirementsTxt: '' # Specify path to Python requirements.txt for BlackDuck
+  useRequirementsTxt: false # Tell the pipeline to use Python requirements.txt for BlackDuck
 
 steps:
   # Synopsys Polaris

--- a/miscellaneous/build_templates/analysis.yml
+++ b/miscellaneous/build_templates/analysis.yml
@@ -1,33 +1,8 @@
 parameters:
-  runBinSkim: false # Opt-in to BinSkim only for dotnet samples
-  deleteBinSkim: '' # This parameter is used to delete files before running BinSkim. Only use this if the error has been investigated and can be safely ignored
   skipPolaris: false # For samples that have no code Polaris is capable of scanning
   useRequirementsTxt: false # Tell the pipeline to use Python requirements.txt for BlackDuck
 
 steps:
-  # BinSkim errors if it encounters badly signed Microsoft files
-  # To avoid this issue, delete the files before running BinSkim
-  - task: DeleteFiles@1
-    displayName: 'BinSkim (DotNet): Delete Files'
-    inputs:
-      SourceFolder: $(Build.SourcesDirectory)$(projPath)
-      Contents: '${{ parameters.deleteBinSkim }}'
-    condition: and(eq(${{ parameters.runBinSkim }}, true), ne('${{ parameters.deleteBinSkim }}', ''))
-
-  - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-binskim.BinSkim@3
-    displayName: 'BinSkim (DotNet): Analyze'
-    inputs:
-      AnalyzeTarget: '$(Build.SourcesDirectory)\*.dll;$(Build.SourcesDirectory)\*.exe'
-      toolVersion: LatestPreRelease
-    condition: eq(${{ parameters.runBinSkim }}, true)
-
-  - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-postanalysis.PostAnalysis@1
-    displayName: 'BinSkim (DotNet): Post-Analysis'
-    inputs:
-      BinSkim: true
-      BinSkimBreakOn: WarningAbove
-    condition: eq(${{ parameters.runBinSkim }}, true)
-
   # Synopsys Polaris
   - powershell: |
       # Set up Polaris Project Name, Access Token

--- a/miscellaneous/build_templates/analysis.yml
+++ b/miscellaneous/build_templates/analysis.yml
@@ -2,7 +2,7 @@ parameters:
   runBinSkim: false # Opt-in to BinSkim only for dotnet samples
   deleteBinSkim: '' # This parameter is used to delete files before running BinSkim. Only use this if the error has been investigated and can be safely ignored
   skipPolaris: false # For samples that have no code Polaris is capable of scanning
-  useRequirements: false # Tell the pipeline to use Python requirements.txt for BlackDuck
+  useRequirementsTxt: false # Tell the pipeline to use Python requirements.txt for BlackDuck
 
 steps:
   # BinSkim errors if it encounters badly signed Microsoft files

--- a/miscellaneous/build_templates/analysis.yml
+++ b/miscellaneous/build_templates/analysis.yml
@@ -1,191 +1,69 @@
 parameters:
-  language: ''
-  lib: false
-  skipBinSkim: false # Tells the analysis pipeline not to run BinSkim as it doesn't work for some samples
-  deleteBinSkim: '' # This parameter is used to delete files before running BinSkim. Only use this if the error has been investigated and can be safely ignored 
+  runBinSkim: false # Opt-in to BinSkim only for dotnet samples
+  deleteBinSkim: '' # This parameter is used to delete files before running BinSkim. Only use this if the error has been investigated and can be safely ignored
   skipPolaris: false # For samples that have no code Polaris is capable of scanning
-  useRequirementsTxt: false # Tell the pipeline to use requirements.txt even if the language is not Python, e.g. Jupyter
-  npmBuild: false # Tell the pipeline whether to run npm build before BlackDuck/Python. Grafana is an instance where this is used
+  useRequirements: false # Tell the pipeline to use Python requirements.txt for BlackDuck
 
-jobs:
-  - job: Analysis
-    pool:
-      name: 00-OSIManaged-Test
-      demands: COMPUTERNAME -equals $(buildAgent)
-    steps:
-      # Remove ".placeholder" from filenames
-      - bash: |
-          for filename in $(find -name '*.placeholder*')
-          do [ -f "$filename" ] || continue
-          mv "$filename" "${filename//.placeholder/}"
-          done
-        workingDirectory: $(Build.SourcesDirectory)$(projPath)/
-        displayName: 'Rename Placeholders'
-      
-      # Build Sample
-      # - DotNet
-      # - Note: --ignore-failed-sources is sometimes necessary for build agent to overcome old
-      #         cached NuGet sources that no longer exist on the machine
-      - script: |
-          echo Clean
-          call dotnet clean
-          echo Build
-          call dotnet build
-          echo Complete
-        workingDirectory: $(Build.SourcesDirectory)$(projPath)/
-        displayName: 'Build (DotNet)'
-        condition: eq('${{ parameters.language }}', 'dotnet')
+steps:
+  # BinSkim errors if it encounters badly signed Microsoft files
+  # To avoid this issue, delete the files before running BinSkim
+  - task: DeleteFiles@1
+    displayName: 'BinSkim (DotNet): Delete Files'
+    inputs:
+      SourceFolder: $(Build.SourcesDirectory)$(projPath)
+      Contents: '${{ parameters.deleteBinSkim }}'
+    condition: and(eq(${{ parameters.runBinSkim }}, true), ne('${{ parameters.deleteBinSkim }}', ''))
 
-      # - Java
-      - script: |
-          echo Install
-          call mvn install -f pom.xml -DskipTests
-          echo Compile
-          call mvn compile
-          echo Complete
-        workingDirectory: $(Build.SourcesDirectory)$(projPath)/
-        displayName: 'Build (Java)'
-        condition: eq('${{ parameters.language }}', 'java')
+  - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-binskim.BinSkim@3
+    displayName: 'BinSkim (DotNet): Analyze'
+    inputs:
+      AnalyzeTarget: '$(Build.SourcesDirectory)\*.dll;$(Build.SourcesDirectory)\*.exe'
+      toolVersion: LatestPreRelease
+    condition: eq(${{ parameters.runBinSkim }}, true)
 
-      # - Python
-      - script: |
-          echo Install tools
-          call pip install setuptools wheel
-          call pip install unittest-xml-reporting
-          call pip install pytest
-          call pip install pytest-cov
-          echo Requirements
-          call pip install -r requirements.txt
-          echo Complete
-        workingDirectory: $(Build.SourcesDirectory)$(projPath)/
-        displayName: 'Build (Python): Install dependencies'
-        condition: and(eq('${{ parameters.language }}', 'python'), eq(${{ parameters.lib }}, false))
-      - script: |
-          echo Install tools
-          call pip install wheel
-          call pip install twine
-          echo Build library
-          call python setup.py sdist bdist_wheel
-          echo Complete
-        workingDirectory: $(Build.SourcesDirectory)$(projPath)/
-        displayName: 'Build (Python Library)'
-        condition: and(eq('${{ parameters.language }}', 'python'), eq(${{ parameters.lib }}, true))
-      
-      # - Jupyter
-      - script: |
-          echo Requirements
-          call pip install -r requirements.txt
-          echo TestRequirements
-          call pip install -r test-requirements.txt
-          echo ConvertToPython
-          jupyter nbconvert --to script *.ipynb
-          echo Complete
-        workingDirectory: $(Build.SourcesDirectory)$(projPath)/
-        displayName: 'Build (Jupyter): Install dependencies'
-        condition:
-          eq('${{ parameters.language }}', 'jupyter')
-      
-      # - Angular
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '10.x'
-        displayName: 'Build (Angular): Specify Node version'
-        condition: eq('${{ parameters.language }}', 'angular')
-      - script: |
-          echo Angular CLI
-          call npm install -g @angular/cli
-          echo NPM CI
-          call npm ci
-          echo Build
-          call npm run build
-          echo Complete
-        workingDirectory: $(Build.SourcesDirectory)$(projPath)/
-        displayName: 'Build (Angular)'
-        condition: eq('${{ parameters.language }}', 'angular')
+  - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-postanalysis.PostAnalysis@1
+    displayName: 'BinSkim (DotNet): Post-Analysis'
+    inputs:
+      BinSkim: true
+      BinSkimBreakOn: WarningAbove
+    condition: eq(${{ parameters.runBinSkim }}, true)
 
-      # - NodeJS
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '10.x'
-        displayName: 'Build (NodeJS): Specify Node version'
-        condition: eq('${{ parameters.language }}', 'nodejs')
-      - script: npm ci
-        workingDirectory: $(Build.SourcesDirectory)$(projPath)/
-        displayName: 'Build (NodeJS): Install dependencies'
-        condition: eq('${{ parameters.language }}', 'nodejs')
-      - script: npm run build
-        workingDirectory: $(Build.SourcesDirectory)$(projPath)/
-        displayName: 'Build (NodeJS): Run build'
-        condition: and(eq('${{ parameters.language }}', 'nodejs'), eq('${{ parameters.npmBuild }}', true))
+  # Synopsys Polaris
+  - powershell: |
+      # Set up Polaris Project Name, Access Token
+      New-Item -Path Env:\ -Name POLARIS_PROJECT_NAME -Value $(analysisProject)
+      New-Item -Path Env:\ -Name POLARIS_ACCESS_TOKEN -Value $(polarisToken)
 
-      # - PowerBI
-      - script: |
-          dotnet restore
-          call vsdevcmd
-          call msbuild
-        workingDirectory: $(Build.SourcesDirectory)$(projPath)/
-        displayName: 'Build (PowerBI)'
-        condition: eq('${{ parameters.language }}', 'powerbi')
+      # Call Polaris, set the configuration file path and run analyze with wait option
+      & 'polaris.exe' -c polaris.yml analyze -w
+    workingDirectory: $(Build.SourcesDirectory)$(projPath)/
+    condition: eq(${{ parameters.skipPolaris }}, false)
+    displayName: 'Polaris Analyze'
 
-      # BinSkim errors if it encounters badly signed Microsoft files
-      # To avoid this issue, delete the files before running BinSkim
-      - task: DeleteFiles@1
-        displayName: 'BinSkim (DotNet): Delete Files'
-        inputs:
-          SourceFolder: $(Build.SourcesDirectory)$(projPath)
-          Contents: '${{ parameters.deleteBinSkim }}'
-        condition: and(eq('${{ parameters.language }}', 'dotnet'), eq(${{ parameters.skipBinSkim }}, false), ne('${{ parameters.deleteBinSkim }}', ''))
+  # Synopsys BlackDuck
+  - task: synopsys-detect.synopsys-detect.synopsys-detect-task.SynopsysDetectTask@2
+    inputs:
+      Products: BD
+      BlackDuckService: 'product-readiness.BlackDuck'
+      DetectArguments: |
+        --detect.project.name="product-readiness.$(analysisProject)"
+        --detect.project.version.name="$(Build.SourceBranchName)"
+        --detect.source.path=$(Build.SourcesDirectory)$(projPath)/
+        --detect.code.location.name="code_location_$(analysisProject)_$(Build.SourceBranchName)"
+        --detect.bom.aggregate.name="bom_$(analysisProject)_$(Build.SourceBranchName)"
+    condition: and(succeeded(), eq(${{ parameters.useRequirementsTxt }}, false))
+    displayName: 'Synopsys Detect: BlackDuck'
 
-      - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-binskim.BinSkim@3
-        displayName: 'BinSkim (DotNet): Analyze'
-        inputs:
-          AnalyzeTarget: '$(Build.SourcesDirectory)\*.dll;$(Build.SourcesDirectory)\*.exe'
-          toolVersion: LatestPreRelease
-        condition: and(eq('${{ parameters.language }}', 'dotnet'), eq(${{ parameters.skipBinSkim }}, false))
-
-      - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-postanalysis.PostAnalysis@1
-        displayName: 'BinSkim (DotNet): Post-Analysis'
-        inputs:
-          BinSkim: true
-          BinSkimBreakOn: WarningAbove
-        condition: and(eq('${{ parameters.language }}', 'dotnet'), eq(${{ parameters.skipBinSkim }}, false))
-
-      # Synopsys Polaris
-      - powershell: |
-          # Set up Polaris Project Name, Access Token
-          New-Item -Path Env:\ -Name POLARIS_PROJECT_NAME -Value $(analysisProject)
-          New-Item -Path Env:\ -Name POLARIS_ACCESS_TOKEN -Value $(polarisToken)
-
-          # Call Polaris, set the configuration file path and run analyze with wait option
-          & 'polaris.exe' -c polaris.yml analyze -w
-        workingDirectory: $(Build.SourcesDirectory)$(projPath)/
-        condition: and(eq(${{ parameters.skipPolaris }}, false), or(eq('${{ parameters.language }}', 'dotnet'), eq('${{ parameters.language }}', 'java'), eq('${{ parameters.language }}', 'python'), eq('${{ parameters.language }}', 'jupyter'), eq('${{ parameters.language }}', 'angular'), eq('${{ parameters.language }}', 'nodejs')))
-        displayName: 'Polaris Analyze'
-
-      # Synopsys BlackDuck
-      - task: synopsys-detect.synopsys-detect.synopsys-detect-task.SynopsysDetectTask@2
-        inputs:
-          Products: BD
-          BlackDuckService: 'product-readiness.BlackDuck'
-          DetectArguments: |
-            --detect.project.name="product-readiness.$(analysisProject)"
-            --detect.project.version.name="$(Build.SourceBranchName)"
-            --detect.source.path=$(Build.SourcesDirectory)$(projPath)/
-            --detect.code.location.name="code_location_$(analysisProject)_$(Build.SourceBranchName)"
-            --detect.bom.aggregate.name="bom_$(analysisProject)_$(Build.SourceBranchName)"
-        condition: and(succeeded(), eq(${{ parameters.useRequirementsTxt }}, false), or(ne('${{ parameters.language }}', 'python'), eq(${{ parameters.lib }}, true)))
-        displayName: 'Synopsys Detect: BlackDuck'
-
-      - task: synopsys-detect.synopsys-detect.synopsys-detect-task.SynopsysDetectTask@2
-        inputs:
-          Products: BD
-          BlackDuckService: 'product-readiness.BlackDuck'
-          DetectArguments: |
-            --detect.project.name="product-readiness.$(analysisProject)"
-            --detect.project.version.name="$(Build.SourceBranchName)"
-            --detect.source.path=$(Build.SourcesDirectory)$(projPath)/
-            --detect.code.location.name="code_location_$(analysisProject)_$(Build.SourceBranchName)"
-            --detect.bom.aggregate.name="bom_$(analysisProject)_$(Build.SourceBranchName)"
-            --detect.pip.requirements.path=$(Build.SourcesDirectory)$(projPath)/requirements.txt
-        condition: and(succeeded(), or(eq(${{ parameters.useRequirementsTxt }}, true), and(eq('${{ parameters.language }}', 'python'), eq(${{ parameters.lib }}, false))))
-        displayName: 'Synopsys Detect: BlackDuck (Python Requirements.txt)'
+  - task: synopsys-detect.synopsys-detect.synopsys-detect-task.SynopsysDetectTask@2
+    inputs:
+      Products: BD
+      BlackDuckService: 'product-readiness.BlackDuck'
+      DetectArguments: |
+        --detect.project.name="product-readiness.$(analysisProject)"
+        --detect.project.version.name="$(Build.SourceBranchName)"
+        --detect.source.path=$(Build.SourcesDirectory)$(projPath)/
+        --detect.code.location.name="code_location_$(analysisProject)_$(Build.SourceBranchName)"
+        --detect.bom.aggregate.name="bom_$(analysisProject)_$(Build.SourceBranchName)"
+        --detect.pip.requirements.path=$(Build.SourcesDirectory)$(projPath)/requirements.txt
+    condition: and(succeeded(), eq(${{ parameters.useRequirementsTxt }}, true))
+    displayName: 'Synopsys Detect: BlackDuck (Python Requirements.txt)'

--- a/miscellaneous/build_templates/analysis.yml
+++ b/miscellaneous/build_templates/analysis.yml
@@ -1,6 +1,6 @@
 parameters:
   skipPolaris: false # For samples that have no code Polaris is capable of scanning
-  requirementsPath: '' # Specify path to Python requirements.txt for BlackDuck
+  useRequirementsTxt: '' # Specify path to Python requirements.txt for BlackDuck
 
 steps:
   # Synopsys Polaris
@@ -11,8 +11,7 @@ steps:
 
       # Call Polaris, set the configuration file path and run analyze with wait option
       & 'polaris.exe' -c polaris.yml analyze -w
-    workingDirectory: $(Build.SourcesDirectory)$(projPath)/
-    condition: and(succeeded(), eq(${{ parameters.skipPolaris }}, false))
+    condition: eq(${{ parameters.skipPolaris }}, false)
     displayName: 'Polaris Analyze'
 
   # Synopsys BlackDuck
@@ -23,9 +22,22 @@ steps:
       DetectArguments: |
         --detect.project.name="product-readiness.$(analysisProject)"
         --detect.project.version.name="$(Build.SourceBranchName)"
-        --detect.source.path=$(Build.SourcesDirectory)$(projPath)/
+        --detect.source.path=$(Build.SourcesDirectory)/
         --detect.code.location.name="code_location_$(analysisProject)_$(Build.SourceBranchName)"
         --detect.bom.aggregate.name="bom_$(analysisProject)_$(Build.SourceBranchName)"
-        --detect.pip.requirements.path=${{ parameters.requirementsPath }}
-    condition: succeeded()
+    condition: eq(${{ parameters.useRequirementsTxt }}, false)
     displayName: 'Synopsys Detect: BlackDuck'
+
+  - task: synopsys-detect.synopsys-detect.synopsys-detect-task.SynopsysDetectTask@2
+    inputs:
+      Products: BD
+      BlackDuckService: 'product-readiness.BlackDuck'
+      DetectArguments: |
+        --detect.project.name="product-readiness.$(analysisProject)"
+        --detect.project.version.name="$(Build.SourceBranchName)"
+        --detect.source.path=$(Build.SourcesDirectory)/
+        --detect.code.location.name="code_location_$(analysisProject)_$(Build.SourceBranchName)"
+        --detect.bom.aggregate.name="bom_$(analysisProject)_$(Build.SourceBranchName)"
+        --detect.pip.requirements.path=$(Build.SourcesDirectory)/requirements.txt
+    condition: eq(${{ parameters.useRequirementsTxt }}, true)
+    displayName: 'Synopsys Detect: BlackDuck (Python Requirements.txt)'

--- a/miscellaneous/build_templates/binskim.yml
+++ b/miscellaneous/build_templates/binskim.yml
@@ -1,0 +1,24 @@
+parameters:
+  deleteBinSkim: '' # This parameter is used to delete files before running BinSkim. Only use this if the error has been investigated and can be safely ignored
+
+steps:
+  # BinSkim errors if it encounters badly signed Microsoft files
+  # To avoid this issue, delete the files before running BinSkim
+  - task: DeleteFiles@1
+    displayName: 'BinSkim: Delete Files'
+    inputs:
+      SourceFolder: $(Build.SourcesDirectory)$(projPath)
+      Contents: '${{ parameters.deleteBinSkim }}'
+    condition: ne('${{ parameters.deleteBinSkim }}', '')
+
+  - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-binskim.BinSkim@3
+    displayName: 'BinSkim: Analyze'
+    inputs:
+      AnalyzeTarget: '$(Build.SourcesDirectory)\*.dll;$(Build.SourcesDirectory)\*.exe'
+      toolVersion: LatestPreRelease
+
+  - task: ms-codeanalysis.vss-microsoft-security-code-analysis-devops.build-task-postanalysis.PostAnalysis@1
+    displayName: 'BinSkim: Post-Analysis'
+    inputs:
+      BinSkim: true
+      BinSkimBreakOn: WarningAbove


### PR DESCRIPTION
This PR removes the build portions of the analysis template, leaving only the Polaris and BlackDuck steps. This should allow the analysis steps to be run at the end of the tests without running their own explicit build.

- This is how BlackDuck is recommended to run anyway
- Should save a small amount of build time, no second build for analysis
- Allows using one job and one agent to complete the tests and pipelines
- No need for language parameter in analysis, only 'useRequirementsTxt' flag for Python/Jupyter and 'skipPolaris' where required
- BinSkim moved to its own template since it is dotnet-specific, so that those steps don't clutter up all our build pipelines
- This way analysis can be run on internal pool or on IAC8188 depending on requirements, rather than having the pool defined inside the template
- Linux builds should skip running the analysis steps since Linux agents do not have Polaris