### PR TITLE
Use newer polaris CLI

### DIFF
--- a/miscellaneous/build_templates/code-analysis.yml
+++ b/miscellaneous/build_templates/code-analysis.yml
@@ -31,7 +31,9 @@ jobs:
   timeoutInMinutes: 180
   pool:
       name: 00-OSIManaged-Containers
-      demands: Agent.OS -equals Windows_NT
+      demands: 
+      - Agent.OS -equals Windows_NT
+      - POLARISCLI -equals 1.18.22
   steps:
     - ${{ parameters.buildSteps }}
     


### PR DESCRIPTION
DevOps are still upgrading their agents so we need to enforce this, see here https://teams.microsoft.com/l/message/19:a6d4e683181946c496889c0aa0bb3ee8@thread.tacv2/1643041912962?tenantId=425a5546-5a6e-4f1b-ab62-23d91d07d893&groupId=bc350b15-e4de-400c-8076-7deb7514c3d7&parentMessageId=1643041912962&teamName=OIMBU%20Developer%20Forums&channelName=Azure%20DevOps&createdTime=1643041912962