### PR TITLE
Fix slashes in binskim.yml

### DIFF
--- a/miscellaneous/build_templates/binskim.yml
+++ b/miscellaneous/build_templates/binskim.yml
@@ -27,7 +27,7 @@ steps:
   displayName: Copy files into binskim
   inputs:
     SourceFolder: '$(Build.SourcesDirectory)'
-    TargetFolder: '$(Pipeline.Workspace)\\binskim'
+    TargetFolder: '$(Pipeline.Workspace)/binskim'
     ${{ if ne(parameters.binskimPath, '') }}:
       Contents: ${{ parameters.binskimPath }}
     ${{ else }}:


### PR DESCRIPTION
### Fix slashes in miscellaneous/build_templates/binskim.yml "Copy files into binskim" step

The previous copy command used parameter "TargetFolder: '$(Pipeline.Workspace)\\\\binskim'". On Linux, which is the OS of the agent pool used for code analysis, this would result in binaries being copied to a folder called "\binskim" and then binskim would fail to find anything because it is looking for just "binskim". 

Changed the slashes from \\\\ to / to fix this. This will work on both Linux and Windows agents.